### PR TITLE
Corrected the background colour of sticky header

### DIFF
--- a/video_app/static/video_app/css/session_detail.css
+++ b/video_app/static/video_app/css/session_detail.css
@@ -382,7 +382,7 @@
 }
 
 .sticky-header {
-    background-color: #ffffff;
+    background-color: #00334C;
     padding: 10px 0;
     display: flex;
     justify-content: center;

--- a/video_app/static/video_app/css/session_detail.css
+++ b/video_app/static/video_app/css/session_detail.css
@@ -382,7 +382,7 @@
 }
 
 .sticky-header {
-    background-color: #00334C;
+    background-color: #E6FDF9;
     padding: 10px 0;
     display: flex;
     justify-content: center;


### PR DESCRIPTION
# Description
As per issue https://github.com/admiralorbiter/EngageKC/issues/9 the background colour of the sticky header was requested to be changed from white to E6FDF9.

# Previous design
![image](https://github.com/user-attachments/assets/f79053ae-7a8b-4559-bf13-731a297731d9)

# New design
![image](https://github.com/user-attachments/assets/4ce57212-cd47-4e7e-8765-50516202466b)

# Implementation
The only code changed is as below.
![image](https://github.com/user-attachments/assets/88744be4-0d64-47bd-b2a4-dd5daa8c4784)


If any changes are needed, please feel free to let me know.